### PR TITLE
add scanning methods from the grazing incidence branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+*~
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/logbook2mouse/file_management.py
+++ b/logbook2mouse/file_management.py
@@ -25,3 +25,15 @@ def scan_counter_next(scan_counter, work_directory, entry):
     else:
         value = scan_counter
     return int(value)
+
+def scan_counter_simple(scan_counter, work_directory):
+    get_no = lambda dirname: int(dirname.split("_")[-1])
+    ymd = entry.date.strftime('%Y%m%d')
+    scan_numbers = np.array([get_no(d) for d in next(os.walk(work_directory))[1] if d.startswith(f"{ymd}_")])
+    if scan_numbers.size == 0:
+        value = 0
+    elif scan_counter <= np.max(scan_numbers):
+        value = np.max(scan_numbers) + 1
+    else:
+        value = scan_counter
+    return int(value)

--- a/logbook2mouse/file_management.py
+++ b/logbook2mouse/file_management.py
@@ -28,8 +28,7 @@ def scan_counter_next(scan_counter, work_directory, entry):
 
 def scan_counter_simple(scan_counter, work_directory):
     get_no = lambda dirname: int(dirname.split("_")[-1])
-    ymd = entry.date.strftime('%Y%m%d')
-    scan_numbers = np.array([get_no(d) for d in next(os.walk(work_directory))[1] if d.startswith(f"{ymd}_")])
+    scan_numbers = np.array([get_no(d) for d in next(os.walk(work_directory))[1] if d.startswith(f"scan_")])
     if scan_numbers.size == 0:
         value = 0
     elif scan_counter <= np.max(scan_numbers):

--- a/logbook2mouse/measure_config.py
+++ b/logbook2mouse/measure_config.py
@@ -151,7 +151,7 @@ def measure_dataset(
         measure_profile(
             entry.sampleposition, store_location, experiment, mode=mode, duration=20
         )
-    move_to_sampleposition(experiment, entry)
+    move_to_sampleposition(experiment, entry.sampleposition)
     move_motor("bsr", bsr, prefix="ims")
     epics.caput("source_cu:shutter", 1, wait=True)
     epics.caput(f"{experiment.parrot_prefix}:exp:count_time", duration)

--- a/logbook2mouse/measure_config.py
+++ b/logbook2mouse/measure_config.py
@@ -119,14 +119,15 @@ def measure_profile(
     else:
         raise ValueError(f"Unknown profile measurement mode {mode}. Available options: 'blank', 'sample', 'scan'.")
 
-    epics.caput("source_cu:shutter", 1, wait=True)
+    if mode in ["blank", "sample"]:
+        epics.caput("source_cu:shutter", 1, wait=True)
     detector.measurement(
         experiment,
         duration=duration,
         store_location=beamprofilepath,
     )
-
-    epics.caput("source_cu:shutter", 0, wait=True)
+    if mode in ["blank", "sample"]:
+        epics.caput("source_cu:shutter", 0, wait=True)
 
     # communicate to image processing ioc which expects the _data_*h5 files
     for fname in beamprofilepath.glob("*data*.h5"):

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -12,7 +12,7 @@ import os
 
 def create_scandir(work_dir):
     new_dir_no = scan_counter_simple(0, work_dir)
-    scandir = work_dir / f"scan_{new_dir_no}",
+    scandir = work_dir / f"scan_{new_dir_no}"
     os.makedirs(scandir,
                 exist_ok = True)
     return scandir

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -50,8 +50,8 @@ def scan(motorname, scan_start, scan_end, npoints,
                              current_pos + scan_end,
                              npoints):
 
-        move_motor(motorname, position = point, prefix = prefix,
-                   parrot_prefix = experiment.parrot_prefix)
+        actual_pos = move_motor(motorname, position = point, prefix = prefix,
+                                parrot_prefix = experiment.parrot_prefix)
 
         store_point = store_location / f"scan_{counter}"
         counter += 1
@@ -65,7 +65,7 @@ def scan(motorname, scan_start, scan_end, npoints,
         with open(scan_csv, "a", newline = "") as current_file:
             writer = DictWriter(current_file,
                                 fieldnames = ["point", "value"])
-            writer.writerow({"point": point, "value": transmission})
+            writer.writerow({"point": actual_pos, "value": transmission})
 
     epics.caput("source_cu:shutter", 0, wait=True)
     # move back to initial position

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -5,7 +5,7 @@ import epics
 from csv import DictWriter
 from pathlib import Path
 import numpy as np
-import os
+import os, time
 
 
 
@@ -59,6 +59,8 @@ def scan(motorname, scan_start, scan_end, npoints,
                         mode="scan",
                         duration=seconds)
 
+        time.sleep(.2)  # hopefully ensuring we get the transmission
+        # corresponding to the latest file
         transmission = epics.caget(transmission_addr)
         with open(scan_csv, "a", newline = "") as current_file:
             writer = DictWriter(current_file,

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -1,4 +1,4 @@
-from logbook2mouse.measure_config import move_motor, measure_profile
+from logbook2mouse.measure_config import move_motor, measure_profile, move_to_sampleposition
 from logbook2mouse.experiment import get_address
 import epics
 from csv import DictWriter
@@ -14,9 +14,11 @@ def scan(motorname, scan_start, scan_end, npoints,
     current_pos = epics.caget(motor_addr)
 
     # measure direct beam as a reference
+    move_to_sampleposition(experiment, sampleposition, blank = True)
     measure_profile(entry, store_location, experiment,
                     mode="blank",
                     duration=seconds)
+    move_to_sampleposition(experiment, sampleposition)
 
     # write values to where the dashboard can see them
     scan_csv = Path("/home/ws8665-epics/scan-using-epics-ioc/") / "current_scan.csv"

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -12,7 +12,7 @@ import os
 
 def create_scandir(work_dir):
     new_dir_no = scan_counter_simple(0, work_dir)
-    scandir = work_dir / f"{ymd}_{new_dir_no}",
+    scandir = work_dir / f"scan_{new_dir_no}",
     os.makedirs(scandir,
                 exist_ok = True)
     return scandir

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -1,9 +1,21 @@
 from logbook2mouse.measure_config import move_motor, measure_profile, move_to_sampleposition
 from logbook2mouse.experiment import get_address
+from logbook2mouse.file_management import scan_counter_simple
 import epics
 from csv import DictWriter
 from pathlib import Path
 import numpy as np
+import os
+
+
+
+
+def create_scandir(work_dir):
+    new_dir_no = scan_counter_simple(0, work_dir)
+    scandir = work_dir / f"{ymd}_{new_dir_no}",
+    os.makedirs(scandir,
+                exist_ok = True)
+    return scandir
 
 def scan(motorname, scan_start, scan_end, npoints,
          seconds,
@@ -12,6 +24,7 @@ def scan(motorname, scan_start, scan_end, npoints,
     motor_addr = get_address(experiment, motorname)
     prefix = motor_addr.rstrip(f":{motorname}")
     current_pos = epics.caget(motor_addr)
+    store_location = create_scandir(store_location)
 
     # measure direct beam as a reference
     move_to_sampleposition(experiment, sampleposition, blank = True)

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -11,6 +11,8 @@ import os
 
 
 def create_scandir(work_dir):
+    os.makedirs(work_dir,
+                exist_ok = True)
     new_dir_no = scan_counter_simple(0, work_dir)
     scandir = work_dir / f"scan_{new_dir_no}"
     os.makedirs(scandir,

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -27,7 +27,7 @@ def scan(motorname, scan_start, scan_end, npoints,
 
     # get pv address of transmission / image ratio
     transmission_addr = get_address(experiment, "ratio")
-
+    counter = 0
     for point in np.linspace(current_pos + scan_start,
                              current_pos + scan_end,
                              npoints):
@@ -35,7 +35,9 @@ def scan(motorname, scan_start, scan_end, npoints,
         move_motor(motorname, position = point, prefix = prefix,
                    parrot_prefix = experiment.parrot_prefix)
 
-        measure_profile(entry, store_location, experiment,
+        store_point = store_location / f"scan_{counter}"
+        counter += 1
+        measure_profile(entry, store_point, experiment,
                         mode="scan",
                         duration=seconds)
 

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -43,6 +43,7 @@ def scan(motorname, scan_start, scan_end, npoints,
     # get pv address of transmission / image ratio
     transmission_addr = get_address(experiment, "ratio")
     counter = 0
+    epics.caput("source_cu:shutter", 1, wait=True)
     for point in np.linspace(current_pos + scan_start,
                              current_pos + scan_end,
                              npoints):
@@ -62,6 +63,7 @@ def scan(motorname, scan_start, scan_end, npoints,
                                 fieldnames = ["point", "value"])
             writer.writerow({"point": point, "value": transmission})
 
+    epics.caput("source_cu:shutter", 0, wait=True)
     # move back to initial position
     move_motor(motorname, position = current_pos, prefix = prefix,
                parrot_prefix = experiment.parrot_prefix)

--- a/logbook2mouse/scan.py
+++ b/logbook2mouse/scan.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def scan(motorname, scan_start, scan_end, npoints,
          seconds,
-         experiment, entry, store_location):
+         experiment, sampleposition, store_location):
     """Scan and record transmission relative to the current position."""
     motor_addr = get_address(experiment, motorname)
     prefix = motor_addr.rstrip(f":{motorname}")
@@ -15,7 +15,7 @@ def scan(motorname, scan_start, scan_end, npoints,
 
     # measure direct beam as a reference
     move_to_sampleposition(experiment, sampleposition, blank = True)
-    measure_profile(entry, store_location, experiment,
+    measure_profile(sampleposition, store_location, experiment,
                     mode="blank",
                     duration=seconds)
     move_to_sampleposition(experiment, sampleposition)
@@ -39,7 +39,7 @@ def scan(motorname, scan_start, scan_end, npoints,
 
         store_point = store_location / f"scan_{counter}"
         counter += 1
-        measure_profile(entry, store_point, experiment,
+        measure_profile(sampleposition, store_point, experiment,
                         mode="scan",
                         duration=seconds)
 

--- a/protocols/20241204_standard_configuration_minimal.py
+++ b/protocols/20241204_standard_configuration_minimal.py
@@ -5,8 +5,10 @@ from logbook2mouse.measure_config import measure_at_config
 logging.info(f'Starting entry for logbook row {entry.row_index}, sampleID: {entry.sampleid}.')
 
 # Configurations to measure
-if "configuration" in entry.additional_parameters.keys():
-    configuration = entry.additional_parameters['configuration']
+configuration = int(entry.additional_parameters.get('configuration', 125))
+repetitions = entry.additional_parameters.get('repetitions', None)
+if repetitions is not None:
+    repetitions = int(repetitions)
 # else:  # specify configuration manually here
 
 # Simulate starting the measurement
@@ -16,6 +18,6 @@ print(f"Starting measurement for sample {entry.proposal}-{entry.sampleid} in con
 measure_at_config(config_no = configuration,
                   entry = entry,
                   experiment = experiment,
-                  duration=10,  # default: 600
-                  # repetitions=16  # default: determined by config number
+                  duration=600,  # default: 600
+                  repetitions=repetitions  # default: determined by config number
                   )

--- a/protocols/20241204_standard_configuration_minimal.py
+++ b/protocols/20241204_standard_configuration_minimal.py
@@ -8,7 +8,7 @@ logging.info(f'Starting entry for logbook row {entry.row_index}, sampleID: {entr
 configuration = int(entry.additional_parameters.get('configuration', 125))
 repetitions = entry.additional_parameters.get('repetitions', None)
 if repetitions is not None:
-    repetitions = int(repetitions)
+    repetitions = int(float(repetitions))
 # else:  # specify configuration manually here
 
 # Simulate starting the measurement

--- a/protocols/20241217_scan.py
+++ b/protocols/20241217_scan.py
@@ -15,5 +15,5 @@ if "configuration" in entry.additional_parameters.keys():
 print(f"Starting measurement for sample {entry.proposal}-{entry.sampleid} in configuration {configuration}.")
 
 # blank and transmission measurements are included
-move_to_sampleposition(experiment, entry)
-scan("ysam", -3, 3, 11, 1, experiment, entry, store_location = Path("/tmp/scan"))
+move_to_sampleposition(experiment, entry.sampleposition)
+scan("ysam", -3, 3, 11, 1, experiment, entry.sampleposition, store_location = Path("/tmp/scan"))

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -23,8 +23,8 @@ if configuration is not None:
 
 def get_float_parameter(entry, keyword, default):
     value = entry.additional_parameters.get(keyword, default)
-    if type(value) == list:
-        value = value.pop()
+    if type(value) == str:
+        value = float(value)
     return value
 
 samplelength = get_float_parameter(entry, 'samplelength', 30.)

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -42,6 +42,7 @@ move_to_sampleposition(experiment, entry.sampleposition)
 start_z, sigma = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
                                      scan_dir)
 entry.sampleposition["zheavy"] = start_z
+print("initial zheavy center:" start_z)
 move_to_sampleposition(experiment, entry.sampleposition)
 
 # center horizontal wafer position (with blocked beam)
@@ -52,7 +53,9 @@ y_center = align.horizontal_center(experiment,
                                    entry.sampleposition,
                                    scan_dir)
 # could determine samplewidth here
-move_motor("zheavy", start_z, prefix="mc0")
+print("ysam center:" y_center)
+entry.sampleposition["ysam"] = y_center
+move_to_sampleposition(experiment, entry.sampleposition)
 
 pitch_center, center = align.pitch_align(experiment, start_z=start_z,
                                          start_pitch=0,

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -94,8 +94,8 @@ sampleposition, zheavymodel, pitchmodel = align.pitch_align(experiment,
 entry.sampleposition = sampleposition
 move_to_sampleposition(experiment, entry.sampleposition)
 
-logging.info(f"horizontal position pitch: {pitch_center}°")
-logging.info(f"sample surface, vertical position: {center} mm")
+logging.info(f"horizontal position pitch: {entry.sampleposition['pitchgi']}°")
+logging.info(f"sample surface, vertical position: {entry.sampleposition['zheavy']} mm")
 move_to_sampleposition(experiment, entry.sampleposition)
 
 # measure once at this position - this should make the first measurement of each sample the reference

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -21,11 +21,16 @@ if configuration is not None:
 samplelength = entry.additional_parameters.get('samplelength', 30)
 samplewidth = entry.additional_parameters.get('samplewidth', samplelength)
 
+# define where to save scans
+ymd = entry.date.strftime("%Y%m%d")
+scan_dir = Path(work_directory(entry)) / ymd / f"{ymd}_{entry.batchnum}_{0}" / "scans"
+
 move_to_sampleposition(experiment, entry.sampleposition)
 # does this also set the sample name? Don't think so
 
 # initial value for vertical position
-start_z, sigma = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition)
+start_z, sigma = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
+                                     scan_dir)
 entry.sampleposition["zheavy"] = start_z
 move_to_sampleposition(experiment, entry.sampleposition)
 
@@ -34,7 +39,8 @@ move_motor("zheavy", start_z + 0.5, prefix="mc0")
 y_center = align.horizontal_center(experiment,
                                    (-0.5*samplewidth*1.25,
                                     +0.5*samplewidth*1.25), 31,
-                                   entry.sampleposition)
+                                   entry.sampleposition,
+                                   scan_dir)
 # could determine samplewidth here
 move_motor("zheavy", start_z, prefix="mc0")
 
@@ -42,19 +48,22 @@ pitch_center, center = align.pitch_align(experiment, start_z=start_z,
                                          start_pitch=0,
                                          sigma_beam=sigma,
                                          halfsample=0.5*samplelength,
-                                         entry.sampleposition)
+                                         entry.sampleposition,
+                                         scan_dir)
 move_motor("zheavy", center, prefix="mc0")
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
 rolloffset = 0.9*halfsample
 roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 31,
-                               entry.sampleposition)
+                               entry.sampleposition,
+                               scan_dir)
 
 pitch_center, center = align.pitch_align(experiment, start_z=center,
                                          start_pitch=pitch_center,
                                          sigma_beam=sigma,
                                          halfsample=halfsample,
-                                         entry.sampleposition)
+                                         entry.sampleposition,
+                                         scan_dir)
 logging.info(f"horizontal position pitch: {pitch_center}°")
 logging.info(f"sample surface, vertical position: {center} mm")
 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -75,7 +75,7 @@ entry.sampleposition["pitchgi"] = pitch_center
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
 
-roll_center, new_z = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 40,
+roll_center, new_z = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.5, centerofrotation = 40,
                                sampleposition=entry.sampleposition,
                                zheavymodel=zheavymodel,
                                store_location=scan_dir)

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -46,12 +46,15 @@ print("initial zheavy center:", start_z)
 move_to_sampleposition(experiment, entry.sampleposition)
 
 # center horizontal wafer position (with blocked beam)
+entry.sampleposition["zheavy"] = start_z + 0.5
 move_motor("zheavy", start_z + 0.5, prefix="mc0")
 y_center = align.horizontal_center(experiment,
                                    (-0.5*samplewidth*1.25,
                                     +0.5*samplewidth*1.25), 31,
                                    entry.sampleposition,
                                    scan_dir)
+entry.sampleposition["zheavy"] = start_z
+
 # could determine samplewidth here
 print("ysam center:", y_center)
 entry.sampleposition["ysam"] = y_center

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -40,7 +40,7 @@ move_to_sampleposition(experiment, entry.sampleposition)
 # does this also set the sample name? Don't think so
 
 # initial value for vertical position
-zheavymodel = transmission_models.ZheavyModel()
+zheavymodel = transmission_models.ZheavyModel(center=entry.sampleposition["zheavy"])
 pitchmodel = transmission_models.PitchModel()
 res, zheavymodel = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
                                        zheavymodel,

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -66,13 +66,16 @@ pitch_center, center = align.pitch_align(experiment, start_z=start_z,
                                          halfsample=0.5*samplelength,
                                          sampleposition=entry.sampleposition,
                                          store_location=scan_dir)
+entry.sampleposition["zheavy"] = center
 move_motor("zheavy", center, prefix="mc0")
+entry.sampleposition["pitchgi"] = pitch_center
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
 rolloffset = 0.9*halfsample
 roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 31,
                                sampleposition=entry.sampleposition,
                                store_location=scan_dir)
+entry.sampleposition["rollgi"] = roll_center
 
 pitch_center, center = align.pitch_align(experiment, start_z=center,
                                          start_pitch=pitch_center,
@@ -80,6 +83,10 @@ pitch_center, center = align.pitch_align(experiment, start_z=center,
                                          halfsample=halfsample,
                                          sampleposition=entry.sampleposition,
                                          store_location=scan_dir)
+entry.sampleposition["zheavy"] = center
+move_motor("zheavy", center, prefix="mc0")
+entry.sampleposition["pitchgi"] = pitch_center
+move_motor("pitchgi", pitch_center, prefix="mc0")
 logging.info(f"horizontal position pitch: {pitch_center}°")
 logging.info(f"sample surface, vertical position: {center} mm")
 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -74,8 +74,8 @@ move_motor("zheavy", center, prefix="mc0")
 entry.sampleposition["pitchgi"] = pitch_center
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
-
-roll_center, new_z = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.5, centerofrotation = 40,
+roll_offset = 3 # mm - otherwise it won't work with GI4
+roll_center, new_z = align.roll_align(experiment, y_center, sigma, roll_offset, centerofrotation = 40,
                                sampleposition=entry.sampleposition,
                                zheavymodel=zheavymodel,
                                store_location=scan_dir)

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -42,7 +42,7 @@ move_to_sampleposition(experiment, entry.sampleposition)
 start_z, sigma = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
                                      scan_dir)
 entry.sampleposition["zheavy"] = start_z
-print("initial zheavy center:" start_z)
+print("initial zheavy center:", start_z)
 move_to_sampleposition(experiment, entry.sampleposition)
 
 # center horizontal wafer position (with blocked beam)
@@ -53,7 +53,7 @@ y_center = align.horizontal_center(experiment,
                                    entry.sampleposition,
                                    scan_dir)
 # could determine samplewidth here
-print("ysam center:" y_center)
+print("ysam center:", y_center)
 entry.sampleposition["ysam"] = y_center
 move_to_sampleposition(experiment, entry.sampleposition)
 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -83,8 +83,11 @@ roll_center, new_z = align.roll_align(experiment, y_center, beam_sigma, roll_off
                                       zheavymodel=zheavymodel,
                                       store_location=scan_dir)
 entry.sampleposition["rollgi"] = roll_center
-entry.sampleposition["zheavy"] = entry.sampleposition["zheavy"] + new_z
 move_to_sampleposition(experiment, entry.sampleposition)
+res, zheavymodel = align.zheavy_center(experiment, (-1.0, 1.0), 31,
+                                 entry.sampleposition, zheavymodel, scan_dir)
+entry.sampleposition["zheavy"] = res["center"]
+
 
 sampleposition, zheavymodel, pitchmodel = align.pitch_align(experiment,
                                                             zheavymodel, pitchmodel, 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -48,8 +48,8 @@ pitch_center, center = align.pitch_align(experiment, start_z=start_z,
                                          start_pitch=0,
                                          sigma_beam=sigma,
                                          halfsample=0.5*samplelength,
-                                         entry.sampleposition,
-                                         scan_dir)
+                                         sampleposition=entry.sampleposition,
+                                         store_location=scan_dir)
 move_motor("zheavy", center, prefix="mc0")
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
@@ -62,8 +62,8 @@ pitch_center, center = align.pitch_align(experiment, start_z=center,
                                          start_pitch=pitch_center,
                                          sigma_beam=sigma,
                                          halfsample=halfsample,
-                                         entry.sampleposition,
-                                         scan_dir)
+                                         sampleposition=entry.sampleposition,
+                                         store_location=scan_dir)
 logging.info(f"horizontal position pitch: {pitch_center}°")
 logging.info(f"sample surface, vertical position: {center} mm")
 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -41,7 +41,7 @@ move_to_sampleposition(experiment, entry.sampleposition)
 
 # initial value for vertical position
 zheavymodel = transmission_models.ZheavyModel()
-pitchmodel = transmission_models.ZheavyModel()
+pitchmodel = transmission_models.PitchModel()
 res, zheavymodel = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
                                        zheavymodel,
                                        scan_dir)

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -6,6 +6,7 @@ from logbook2mouse.measure_config import (
 from logbook2mouse.file_management import work_directory
 import mouse_alignment_routines.alignment as align
 from pathlib import Path
+import os
 
 # design needs:
 # - have approximate sample length (and width?) somewhere
@@ -25,6 +26,7 @@ samplewidth = entry.additional_parameters.get('samplewidth', samplelength)
 # define where to save scans
 ymd = entry.date.strftime("%Y%m%d")
 scan_dir = Path(work_directory(entry)) / ymd / f"{ymd}_{entry.batchnum}_{0}" / "scans"
+os.makedirs(scan_dir / "scan_0", exist_ok=True)
 
 move_to_sampleposition(experiment, entry.sampleposition)
 # does this also set the sample name? Don't think so

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -55,8 +55,8 @@ move_motor("pitchgi", pitch_center, prefix="mc0")
 
 rolloffset = 0.9*halfsample
 roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 31,
-                               entry.sampleposition,
-                               scan_dir)
+                               sampleposition=entry.sampleposition,
+                               store_location=scan_dir)
 
 pitch_center, center = align.pitch_align(experiment, start_z=center,
                                          start_pitch=pitch_center,

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -3,7 +3,7 @@
 from logbook2mouse.measure_config import (
     move_motor, move_to_sampleposition, moveto_config,
     measure_at_config)
-import alignment as align  # to do
+import mouse_alignment_routines.alignment as align
 from pathlib import Path
 
 # design needs:

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -3,6 +3,7 @@
 from logbook2mouse.measure_config import (
     move_motor, move_to_sampleposition, moveto_config,
     measure_at_config)
+from logbook2mouse.file_management import work_directory
 import mouse_alignment_routines.alignment as align
 from pathlib import Path
 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -75,10 +75,11 @@ entry.sampleposition["pitchgi"] = pitch_center
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
 roll_offset = 3 # mm - otherwise it won't work with GI4
-roll_center, new_z = align.roll_align(experiment, y_center, sigma, roll_offset, centerofrotation = 40,
-                               sampleposition=entry.sampleposition,
-                               zheavymodel=zheavymodel,
-                               store_location=scan_dir)
+roll_center, new_z = align.roll_align(experiment, y_center, sigma, roll_offset,
+                                      centerofrotation = 37.3376,
+                                      sampleposition=entry.sampleposition,
+                                      zheavymodel=zheavymodel,
+                                      store_location=scan_dir)
 entry.sampleposition["rollgi"] = roll_center
 entry.sampleposition["zheavy"] = entry.sampleposition["zheavy"] + new_z
 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -71,7 +71,6 @@ move_motor("zheavy", center, prefix="mc0")
 entry.sampleposition["pitchgi"] = pitch_center
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
-rolloffset = 0.9*halfsample
 roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 31,
                                sampleposition=entry.sampleposition,
                                store_location=scan_dir)
@@ -80,7 +79,7 @@ entry.sampleposition["rollgi"] = roll_center
 pitch_center, center = align.pitch_align(experiment, start_z=center,
                                          start_pitch=pitch_center,
                                          sigma_beam=sigma,
-                                         halfsample=halfsample,
+                                         halfsample=0.5*samplelength,
                                          sampleposition=entry.sampleposition,
                                          store_location=scan_dir)
 entry.sampleposition["zheavy"] = center

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -77,7 +77,7 @@ entry.sampleposition = sampleposition
 move_to_sampleposition(experiment, entry.sampleposition)
 
 roll_offset = 3 # mm - otherwise it won't work with GI4
-roll_center, new_z = align.roll_align(experiment, y_center, sigma, roll_offset,
+roll_center, new_z = align.roll_align(experiment, y_center, beam_sigma, roll_offset,
                                       centerofrotation = 37.3376,
                                       sampleposition=entry.sampleposition,
                                       zheavymodel=zheavymodel,

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -41,9 +41,9 @@ move_to_sampleposition(experiment, entry.sampleposition)
 
 # initial value for vertical position
 zheavymodel = transmission_models.ZheavyModel()
-start_z, sigma = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
-                                     zheavymodel,
-                                     scan_dir)
+start_z, sigma, zheavymodel = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
+                                                  zheavymodel,
+                                                  scan_dir)
 entry.sampleposition["zheavy"] = start_z
 print("initial zheavy center:", start_z)
 move_to_sampleposition(experiment, entry.sampleposition)

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -1,0 +1,68 @@
+# 20250109_alignment.py
+
+from logbook2mouse.measure_config import (
+    move_motor, move_to_sampleposition, moveto_config,
+    measure_at_config)
+import alignment as align  # to do
+from pathlib import Path
+
+# design needs:
+# - have approximate sample length (and width?) somewhere
+# - package with functions specific to scan analysis. this has no place in logbook2mouse
+# - what modifications from branch 2_multisampleholder are worth keeping?
+# - how to store alignment result
+#   + just in nxs file? -> need to label this file
+#   + create sampleposition dict from nxs file (?)
+
+configuration = entry.additional_parameters.get('configuration', None)
+if configuration is not None:
+    moveto_config(experiment.required_pvs,
+                  config_no = configuration)
+samplelength = entry.additional_parameters.get('samplelength', 30)
+samplewidth = entry.additional_parameters.get('samplewidth', samplelength)
+
+move_to_sampleposition(experiment, entry.sampleposition)
+# does this also set the sample name? Don't think so
+
+# initial value for vertical position
+start_z, sigma = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition)
+entry.sampleposition["zheavy"] = start_z
+move_to_sampleposition(experiment, entry.sampleposition)
+
+# center horizontal wafer position (with blocked beam)
+move_motor("zheavy", start_z + 0.5, prefix="mc0")
+y_center = align.horizontal_center(experiment,
+                                   (-0.5*samplewidth*1.25,
+                                    +0.5*samplewidth*1.25), 31,
+                                   entry.sampleposition)
+# could determine samplewidth here
+move_motor("zheavy", start_z, prefix="mc0")
+
+pitch_center, center = align.pitch_align(experiment, start_z=start_z,
+                                         start_pitch=0,
+                                         sigma_beam=sigma,
+                                         halfsample=0.5*samplelength,
+                                         entry.sampleposition)
+move_motor("zheavy", center, prefix="mc0")
+move_motor("pitchgi", pitch_center, prefix="mc0")
+
+rolloffset = 0.9*halfsample
+roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 31,
+                               entry.sampleposition)
+
+pitch_center, center = align.pitch_align(experiment, start_z=center,
+                                         start_pitch=pitch_center,
+                                         sigma_beam=sigma,
+                                         halfsample=halfsample,
+                                         entry.sampleposition)
+logging.info(f"horizontal position pitch: {pitch_center}°")
+logging.info(f"sample surface, vertical position: {center} mm")
+
+# measure once at this position - this should make the first measurement of each sample the reference
+if configuration is not None:
+    measure_at_config(configuration,
+                      entry,
+                      experiment,
+                      repetitions=1,
+                      duration=60,
+                      )

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -5,6 +5,7 @@ from logbook2mouse.measure_config import (
     measure_at_config)
 from logbook2mouse.file_management import work_directory
 import mouse_alignment_routines.alignment as align
+import mouse_alignment_routines.transmission_models as transmission_models
 from pathlib import Path
 import os
 
@@ -39,7 +40,9 @@ move_to_sampleposition(experiment, entry.sampleposition)
 # does this also set the sample name? Don't think so
 
 # initial value for vertical position
+zheavymodel = transmission_models.ZheavyModel()
 start_z, sigma = align.zheavy_center(experiment, (-1.0, 1.0), 31, entry.sampleposition,
+                                     zheavymodel,
                                      scan_dir)
 entry.sampleposition["zheavy"] = start_z
 print("initial zheavy center:", start_z)
@@ -71,8 +74,10 @@ move_motor("zheavy", center, prefix="mc0")
 entry.sampleposition["pitchgi"] = pitch_center
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
-roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 31,
+
+roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 40,
                                sampleposition=entry.sampleposition,
+                               zheavymodel=zheavymodel,
                                store_location=scan_dir)
 entry.sampleposition["rollgi"] = roll_center
 

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -20,8 +20,15 @@ configuration = entry.additional_parameters.get('configuration', None)
 if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
-samplelength = entry.additional_parameters.get('samplelength', 30)
-samplewidth = entry.additional_parameters.get('samplewidth', samplelength)
+
+def get_float_parameter(entry, keyword, default):
+    value = entry.additional_parameters.get(keyword, default)
+    if type(value) == list:
+        value = value.pop()
+    return value
+
+samplelength = get_float_parameter(entry, 'samplelength', 30.)
+samplewidth = get_float_parameter(entry, 'samplewidth', samplelength)
 
 # define where to save scans
 ymd = entry.date.strftime("%Y%m%d")

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -25,7 +25,7 @@ samplewidth = entry.additional_parameters.get('samplewidth', samplelength)
 
 # define where to save scans
 ymd = entry.date.strftime("%Y%m%d")
-scan_dir = Path(work_directory(entry)) / ymd / f"{ymd}_{entry.batchnum}_{0}" / "scans"
+scan_dir = Path(work_directory(entry)) / f"{ymd}_{entry.batchnum}_{0}" / "scans"
 os.makedirs(scan_dir / "scan_0", exist_ok=True)
 
 move_to_sampleposition(experiment, entry.sampleposition)

--- a/protocols/20250109_alignment.py
+++ b/protocols/20250109_alignment.py
@@ -75,11 +75,12 @@ entry.sampleposition["pitchgi"] = pitch_center
 move_motor("pitchgi", pitch_center, prefix="mc0")
 
 
-roll_center = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 40,
+roll_center, new_z = align.roll_align(experiment, y_center, sigma, 0.5*samplewidth*0.75, centerofrotation = 40,
                                sampleposition=entry.sampleposition,
                                zheavymodel=zheavymodel,
                                store_location=scan_dir)
 entry.sampleposition["rollgi"] = roll_center
+entry.sampleposition["zheavy"] = entry.sampleposition["zheavy"] + new_z
 
 pitch_center, center = align.pitch_align(experiment, start_z=center,
                                          start_pitch=pitch_center,

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -1,0 +1,43 @@
+# 20250116_reflectivity.py
+
+from logbook2mouse.scan import scan
+from logbook2mouse.measure_config import (
+    move_motor, move_motor_fromconfig, moveto_config,
+    measure_at_config)
+from logbook2mouse.file_management import work_directory, scan_counter_next
+from logbook2mouse.experiment import get_address
+from pathlib import Path
+import epics
+
+configuration = entry.additional_parameters.get('configuration', None)
+if configuration is not None:
+    moveto_config(experiment.required_pvs,
+                  config_no = configuration)
+incident_angle = entry.additional_parameters.get('incident_angle', 0.21)
+
+
+ymd = entry.date.strftime("%Y%m%d")
+wd = Path(work_directory(entry)) / ymd
+aligned_data =  wd / f"{ymd}_{entry.batchnum}_{0}")
+scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
+
+# move to aligned position
+for motor in ["ysam", "zheavy", "yawgi", "rollgi", "pitchgi"]:
+    motorname, motorpos = move_motor_fromconfig(motor, imcrawfile=aligned_data/"im_craw.nxs",
+                                                prefix=get_address(motor).split(":")[0]
+                                                )
+    entry.sampleposition[motor] = motorpos
+
+incident_angle_zero = epics.caget(get_address("pitchgi"))
+
+# move to requested angle and measure
+pitch = incident_angle_zero - incident_angle  # pitchgi axis is reversed
+move_motor("pitchgi", pitch)
+measure_at_config(
+    config_id = configuration,
+    entry = entry,
+    repetitions = 10,
+    duration = 600,
+)
+
+

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -17,7 +17,7 @@ incident_angle = entry.additional_parameters.get('incident_angle', 0.21)
 repetitions = entry.additional_parameters.get('repetitions', 10)
 
 ymd = entry.date.strftime("%Y%m%d")
-wd = Path(work_directory(entry)) / ymd
+wd = Path(work_directory(entry))
 aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
 scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -44,6 +44,7 @@ move_motor("pitchgi", pitch)
 measure_at_config(
     config_no = configuration,
     entry = entry,
+    experiment = experiment,
     repetitions = int(repetitions),
     duration = 600,
 )

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -42,7 +42,7 @@ incident_angle_zero = epics.caget(get_address(experiment, "pitchgi"))
 pitch = incident_angle_zero - incident_angle  # pitchgi axis is reversed
 move_motor("pitchgi", pitch)
 measure_at_config(
-    config_id = configuration,
+    config_no = configuration,
     entry = entry,
     repetitions = int(repetitions),
     duration = 600,

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -14,7 +14,7 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 incident_angle = entry.additional_parameters.get('incident_angle', 0.21)
-
+repetitions = entry.additional_parameters.get('repetitions', 10)
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry)) / ymd
@@ -36,7 +36,7 @@ move_motor("pitchgi", pitch)
 measure_at_config(
     config_id = configuration,
     entry = entry,
-    repetitions = 10,
+    repetitions = repetitions,
     duration = 600,
 )
 

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -41,8 +41,10 @@ for motor in ["ysam", "zheavy", "yawgi", "rollgi", "pitchgi"]:
 incident_angle_zero = epics.caget(get_address(experiment, "pitchgi"))
 
 # move to requested angle and measure
-pitch = incident_angle_zero - incident_angle  # pitchgi axis is reversed
+pitch = float(incident_angle_zero) - float(incident_angle)  # pitchgi axis is reversed
 move_motor("pitchgi", pitch)
+entry.sampleposition["pitchgi"] = float(pitch)
+
 measure_at_config(
     config_no = configuration,
     entry = entry,

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -24,7 +24,7 @@ if configuration is not None:
 incident_angle = get_float_parameter(entry, 'incident_angle', 0.21)
 repetitions = entry.additional_parameters.get('repetitions', None)
 if repetitions is not None:
-    repetitions = int(repetitions)
+    repetitions = int(float(repetitions))
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -24,11 +24,11 @@ scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 # move to aligned position
 for motor in ["ysam", "zheavy", "yawgi", "rollgi", "pitchgi"]:
     motorname, motorpos = move_motor_fromconfig(motor, imcrawfile=aligned_data/"im_craw.nxs",
-                                                prefix=get_address(motor).split(":")[0]
+                                                prefix=get_address(experiment, motor).split(":")[0]
                                                 )
     entry.sampleposition[motor] = motorpos
 
-incident_angle_zero = epics.caget(get_address("pitchgi"))
+incident_angle_zero = epics.caget(get_address(experiment, "pitchgi"))
 
 # move to requested angle and measure
 pitch = incident_angle_zero - incident_angle  # pitchgi axis is reversed

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -44,7 +44,7 @@ move_motor("pitchgi", pitch)
 measure_at_config(
     config_id = configuration,
     entry = entry,
-    repetitions = repetitions,
+    repetitions = int(repetitions),
     duration = 600,
 )
 

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -9,11 +9,19 @@ from logbook2mouse.experiment import get_address
 from pathlib import Path
 import epics
 
+def get_float_parameter(entry, keyword, default):
+    value = entry.additional_parameters.get(keyword, default)
+    if type(value) == str:
+        value = float(value)
+    return value
+
 configuration = entry.additional_parameters.get('configuration', None)
 if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
-incident_angle = entry.additional_parameters.get('incident_angle', 0.21)
+
+
+incident_angle = get_float_parameter(entry, 'incident_angle', 0.21)
 repetitions = entry.additional_parameters.get('repetitions', 10)
 
 ymd = entry.date.strftime("%Y%m%d")

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -20,7 +20,9 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
+alignment_batch = entry.additional_parameters.get('alignment_batch', entry.batchnum)
 
+    
 incident_angle = get_float_parameter(entry, 'incident_angle', 0.21)
 repetitions = entry.additional_parameters.get('repetitions', None)
 if repetitions is not None:
@@ -28,7 +30,7 @@ if repetitions is not None:
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))
-aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
+aligned_data =  wd / f"{ymd}_{alignment_batch}_{1}"
 scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 
 # move to aligned position

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -22,7 +22,9 @@ if configuration is not None:
 
 
 incident_angle = get_float_parameter(entry, 'incident_angle', 0.21)
-repetitions = entry.additional_parameters.get('repetitions', 10)
+repetitions = entry.additional_parameters.get('repetitions', None)
+if repetitions is not None:
+    repetitions = int(repetitions)
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -18,7 +18,7 @@ repetitions = entry.additional_parameters.get('repetitions', 10)
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry)) / ymd
-aligned_data =  wd / f"{ymd}_{entry.batchnum}_{0}")
+aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
 scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 
 # move to aligned position

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -20,7 +20,7 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
-alignment_batch = int(entry.additional_parameters.get('alignment_batch', entry.batchnum))
+alignment_batch = int(float(entry.additional_parameters.get('alignment_batch', entry.batchnum)))
 
     
 incident_angle = get_float_parameter(entry, 'incident_angle', 0.21)

--- a/protocols/20250116_gisaxs.py
+++ b/protocols/20250116_gisaxs.py
@@ -20,7 +20,7 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
-alignment_batch = entry.additional_parameters.get('alignment_batch', entry.batchnum)
+alignment_batch = int(entry.additional_parameters.get('alignment_batch', entry.batchnum))
 
     
 incident_angle = get_float_parameter(entry, 'incident_angle', 0.21)

--- a/protocols/20250116_reflectivity.py
+++ b/protocols/20250116_reflectivity.py
@@ -14,7 +14,7 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
-alignment_batch = entry.additional_parameters.get('alignment_batch', entry.batchnum)
+alignment_batch = int(entry.additional_parameters.get('alignment_batch', entry.batchnum))
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))

--- a/protocols/20250116_reflectivity.py
+++ b/protocols/20250116_reflectivity.py
@@ -14,7 +14,7 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
-alignment_batch = int(entry.additional_parameters.get('alignment_batch', entry.batchnum))
+alignment_batch = int(float(entry.additional_parameters.get('alignment_batch', entry.batchnum)))
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))

--- a/protocols/20250116_reflectivity.py
+++ b/protocols/20250116_reflectivity.py
@@ -14,9 +14,11 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
+alignment_batch = entry.additional_parameters.get('alignment_batch', entry.batchnum)
+
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))
-aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
+aligned_data =  wd / f"{ymd}_{alignment_batch}_{1}"
 scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 
 # move to aligned position

--- a/protocols/20250116_reflectivity.py
+++ b/protocols/20250116_reflectivity.py
@@ -22,11 +22,11 @@ scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 # move to aligned position
 for motor in ["ysam", "zheavy", "yawgi", "rollgi", "pitchgi"]:
     motorname, motorpos = move_motor_fromconfig(motor, imcrawfile=aligned_data/"im_craw.nxs",
-                                                prefix=get_address(motor).split(":")[0]
+                                                prefix=get_address(experiment, motor).split(":")[0]
                                                 )
     entry.sampleposition[motor] = motorpos
 
-incident_angle_zero = epics.caget(get_address("pitchgi"))
+incident_angle_zero = epics.caget(get_address(experiment, "pitchgi"))
 
 
 # scan

--- a/protocols/20250116_reflectivity.py
+++ b/protocols/20250116_reflectivity.py
@@ -1,0 +1,39 @@
+# 20250116_reflectivity.py
+
+from logbook2mouse.scan import scan
+from logbook2mouse.measure_config import (
+    move_motor, move_motor_fromconfig, moveto_config,
+    measure_at_config)
+from logbook2mouse.file_management import work_directory, scan_counter_next
+from logbook2mouse.experiment import get_address
+from pathlib import Path
+import epics
+
+configuration = entry.additional_parameters.get('configuration', None)
+if configuration is not None:
+    moveto_config(experiment.required_pvs,
+                  config_no = configuration)
+
+ymd = entry.date.strftime("%Y%m%d")
+wd = Path(work_directory(entry)) / ymd
+aligned_data =  wd / f"{ymd}_{entry.batchnum}_{0}")
+scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
+
+# move to aligned position
+for motor in ["ysam", "zheavy", "yawgi", "rollgi", "pitchgi"]:
+    motorname, motorpos = move_motor_fromconfig(motor, imcrawfile=aligned_data/"im_craw.nxs",
+                                                prefix=get_address(motor).split(":")[0]
+                                                )
+    entry.sampleposition[motor] = motorpos
+
+incident_angle_zero = epics.caget(get_address("pitchgi"))
+
+
+# scan
+scan("pitchgi", -0.6, -0.1, 101,
+     1, # second
+     experiment, entry.sampleposition,
+     scan_dir
+     )
+
+

--- a/protocols/20250116_reflectivity.py
+++ b/protocols/20250116_reflectivity.py
@@ -15,7 +15,7 @@ if configuration is not None:
                   config_no = configuration)
 
 ymd = entry.date.strftime("%Y%m%d")
-wd = Path(work_directory(entry)) / ymd
+wd = Path(work_directory(entry))
 aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
 scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 

--- a/protocols/20250116_reflectivity.py
+++ b/protocols/20250116_reflectivity.py
@@ -16,7 +16,7 @@ if configuration is not None:
 
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry)) / ymd
-aligned_data =  wd / f"{ymd}_{entry.batchnum}_{0}")
+aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
 scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 
 # move to aligned position

--- a/protocols/20250207_high_resolution_reflectivity.py
+++ b/protocols/20250207_high_resolution_reflectivity.py
@@ -14,9 +14,11 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
+alignment_batch = entry.additional_parameters.get('alignment_batch', entry.batchnum)
+    
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))
-aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
+aligned_data =  wd / f"{ymd}_{alignment_batch}_{1}"
 scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
 
 # move to aligned position

--- a/protocols/20250207_high_resolution_reflectivity.py
+++ b/protocols/20250207_high_resolution_reflectivity.py
@@ -1,0 +1,39 @@
+# 20250116_reflectivity.py
+
+from logbook2mouse.scan import scan
+from logbook2mouse.measure_config import (
+    move_motor, move_motor_fromconfig, moveto_config,
+    measure_at_config)
+from logbook2mouse.file_management import work_directory, scan_counter_next
+from logbook2mouse.experiment import get_address
+from pathlib import Path
+import epics
+
+configuration = entry.additional_parameters.get('configuration', None)
+if configuration is not None:
+    moveto_config(experiment.required_pvs,
+                  config_no = configuration)
+
+ymd = entry.date.strftime("%Y%m%d")
+wd = Path(work_directory(entry))
+aligned_data =  wd / f"{ymd}_{entry.batchnum}_{1}"
+scan_dir = wd / f"{ymd}_{entry.batchnum}_{scan_counter_next(0, wd, entry)}"
+
+# move to aligned position
+for motor in ["ysam", "zheavy", "yawgi", "rollgi", "pitchgi"]:
+    motorname, motorpos = move_motor_fromconfig(motor, imcrawfile=aligned_data/"im_craw.nxs",
+                                                prefix=get_address(experiment, motor).split(":")[0]
+                                                )
+    entry.sampleposition[motor] = motorpos
+
+incident_angle_zero = epics.caget(get_address(experiment, "pitchgi"))
+
+
+# scan
+scan("pitchgi", -0.3, -0.1, 401, # 401 points - 0.0005° step size (smallest we can do)
+     1, # second
+     experiment, entry.sampleposition,
+     scan_dir
+     )
+
+

--- a/protocols/20250207_high_resolution_reflectivity.py
+++ b/protocols/20250207_high_resolution_reflectivity.py
@@ -14,7 +14,7 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
-alignment_batch = entry.additional_parameters.get('alignment_batch', entry.batchnum)
+alignment_batch = int(entry.additional_parameters.get('alignment_batch', entry.batchnum))
     
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))

--- a/protocols/20250207_high_resolution_reflectivity.py
+++ b/protocols/20250207_high_resolution_reflectivity.py
@@ -14,7 +14,7 @@ if configuration is not None:
     moveto_config(experiment.required_pvs,
                   config_no = configuration)
 
-alignment_batch = int(entry.additional_parameters.get('alignment_batch', entry.batchnum))
+alignment_batch = int(float(entry.additional_parameters.get('alignment_batch', entry.batchnum)))
     
 ymd = entry.date.strftime("%Y%m%d")
 wd = Path(work_directory(entry))

--- a/protocols/evacuate.py
+++ b/protocols/evacuate.py
@@ -1,0 +1,32 @@
+# this code gets run at the start of every script (not at the start of every entry, but the whole script)
+# use this code to check PVs, generators, etc. 
+import logging
+logger = logging.getLogger("measurement")
+logger.setLevel(logging.INFO)
+from epics import caget
+from pandas import Timestamp
+import logbook2mouse.detector as detector
+from logbook2mouse.logbook_reader import Logbook2MouseEntry
+from logbook2mouse.project_reader import ProjectInfo, Sample, SampleComponent
+from periodictable import formula
+from logbook2mouse.experiment import ExperimentVariables
+
+
+# Required Process Variables (PVs) for this protocol. These will be validated before execution.
+required_pvs = [
+    'ims:detx',
+    'pressure_gauge:pressure',
+    'portenta:do6',
+]
+
+# check that the PVs are reachable before we execute a script:
+for pv in required_pvs:
+    value = caget(pv)
+    if value is None:
+        raise ConnectionError(f"PV '{pv}' is not reachable or has no value.")
+
+experiment = ExperimentVariables(required_pvs)
+
+epics.caput("ims:detx", 400)
+epics.caput("portenta:do7", 0)
+epics.caput("portenta:do6", 1)

--- a/protocols/evacuate.py
+++ b/protocols/evacuate.py
@@ -3,7 +3,7 @@
 import logging
 logger = logging.getLogger("measurement")
 logger.setLevel(logging.INFO)
-from epics import caget
+import epics
 from pandas import Timestamp
 import logbook2mouse.detector as detector
 from logbook2mouse.logbook_reader import Logbook2MouseEntry

--- a/protocols/evacuate.py
+++ b/protocols/evacuate.py
@@ -21,7 +21,7 @@ required_pvs = [
 
 # check that the PVs are reachable before we execute a script:
 for pv in required_pvs:
-    value = caget(pv)
+    value = epics.caget(pv)
     if value is None:
         raise ConnectionError(f"PV '{pv}' is not reachable or has no value.")
 

--- a/protocols/setup.py
+++ b/protocols/setup.py
@@ -15,7 +15,10 @@ from logbook2mouse.experiment import ExperimentVariables
 # Required Process Variables (PVs) for this protocol. These will be validated before execution.
 required_pvs = [
     'mc0:ysam',
-    'mc0:zsam',
+    'mc0:zheavy',
+    'mc0:yawgi',
+    'mc0:rollgi',
+    'mc0:pitchgi',
     'ims:detx',
     'ims:dety',
     'ims:detz',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,11 @@ setup(
     install_requires=[
         'pandas',
         'attrs',
-        'openpyxl'
+        'openpyxl',
+        'h5py',
+        'hdf5plugin',
+        'pyepics',
+        'periodictable',
+        'xraydb',
     ],
 )


### PR DESCRIPTION
Makes scanning available on the main branch.
For a "profile" measurement (used for direct beam, sample beam, and scans) we no longer pass the Logbook2MouseEntry, just its `sampleposition` attribute. 
This assumes all motors except the ones in the sampleposition dictionary are as in the original entry for metadata purposes. 

Further changes are mostly addition of protocols for grazing incidence & xrr